### PR TITLE
Fix in-app browser wallet detection

### DIFF
--- a/sdk/packages/selector-polkadot/src/detection.ts
+++ b/sdk/packages/selector-polkadot/src/detection.ts
@@ -21,14 +21,12 @@ declare global {
 }
 export const getPolkadotWallets = (): PolkadotWalletInjected[] => {
   if (window && window.injectedWeb3) {
-    return Object.entries(window.injectedWeb3).map(([key, value]) => {
-      // value.name might be undefined
-      value.name = value.name ?? key
-      value.slug = key
-      value.icon =
-        value.icon ?? appToIcon[key] ?? 'https://registry.nightly.app/networks/polkadot.png' // TODO add default icon
-      return value
-    })
+    return Object.entries(window.injectedWeb3).map(([key, value]) => ({
+        ...value,
+        name: value.name ?? key, // value.name might be undefined
+        slug: key,
+        icon: value.icon ?? appToIcon[key] ?? 'https://registry.nightly.app/networks/polkadot.png' // TODO add default icon
+      }))
   } else {
     return []
   }


### PR DESCRIPTION
Hi @NorbertBodziony, I've created this PR to address the issue of being unable to use NC within the SubWallet in-app browser.

In-app browsers in SubWallet or Nova inject the wallet into `window.injectedWeb3['polkadot-js']`, which points to the same object such as `window.injectedWeb3['subwallet-js']`.

The getPolkadotWallets method will overwrite the SubWallet's injected object if `polkadot-js` is set after `subwallet-js`. To solve this, I've updated getPolkadotWallets to return a new object with metadata such as name, slug, and icon.

Please help me review and merge this PR.

Many thanks.