### PR TITLE
Aptos refactor

### DIFF
--- a/sdk/apps/modal-example/package.json
+++ b/sdk/apps/modal-example/package.json
@@ -22,7 +22,7 @@
     "@nightlylabs/nightly-connect-polkadot": "0.0.16",
     "@nightlylabs/nightly-connect-solana": "0.0.29",
     "@nightlylabs/nightly-connect-sui": "0.1.0",
-    "@nightlylabs/wallet-selector-aptos": "0.1.6",
+    "@nightlylabs/wallet-selector-aptos": "0.1.7",
     "@nightlylabs/wallet-selector-base": "^0.4.1",
     "@nightlylabs/wallet-selector-polkadot": "0.2.7",
     "@nightlylabs/wallet-selector-solana": "0.3.6",

--- a/sdk/apps/modal-example/src/routes/aptos.tsx
+++ b/sdk/apps/modal-example/src/routes/aptos.tsx
@@ -75,9 +75,6 @@ export default function AptosPage() {
         )
     }
   })
-  createEffect(() => {
-    console.log(accountInfo())
-  })
 
   return (
     <main>

--- a/sdk/apps/modal-example/src/routes/aptos.tsx
+++ b/sdk/apps/modal-example/src/routes/aptos.tsx
@@ -2,7 +2,9 @@ import {
   AccountAuthenticator,
   AccountAuthenticatorEd25519,
   AnyRawTransaction,
-  Aptos
+  Aptos,
+  AccountPublicKey,
+  Network
 } from '@aptos-labs/ts-sdk'
 import { AccountInfo, AptosSignMessageInput, UserResponseStatus } from '@aptos-labs/wallet-standard'
 import { NightlyConnectAptosAdapter } from '@nightlylabs/wallet-selector-aptos'
@@ -92,6 +94,17 @@ export default function AptosPage() {
         <button
           onClick={async () => {
             try {
+              try {
+                await aptos.getAccountInfo({
+                  accountAddress: accountInfo()!.address.toString()
+                })
+              } catch (error) {
+                await aptos.fundAccount({
+                  accountAddress: accountInfo()!.address.toString(),
+                  amount: 100_000_000
+                })
+              }
+
               const transaction = await aptos.transaction.build.simple({
                 sender: accountInfo()!.address.toString(),
                 data: {
@@ -103,6 +116,8 @@ export default function AptosPage() {
                   ]
                 }
               })
+
+              console.log(transaction)
               const signedTx = await adapter()!.signAndSubmitTransaction(transaction)
               // Verify the transaction was signed
               if (signedTx.status !== UserResponseStatus.APPROVED) {
@@ -121,6 +136,17 @@ export default function AptosPage() {
         <button
           onClick={async () => {
             try {
+              try {
+                await aptos.getAccountInfo({
+                  accountAddress: accountInfo()!.address.toString()
+                })
+              } catch (error) {
+                await aptos.fundAccount({
+                  accountAddress: accountInfo()!.address.toString(),
+                  amount: 100_000_000
+                })
+              }
+
               const transaction = await aptos.transaction.build.simple({
                 sender: accountInfo()!.address.toString(),
                 data: {

--- a/sdk/apps/modal-example/src/routes/aptosCustom.tsx
+++ b/sdk/apps/modal-example/src/routes/aptosCustom.tsx
@@ -1,5 +1,17 @@
-import { AccountAuthenticator, AccountAuthenticatorEd25519, Aptos } from '@aptos-labs/ts-sdk'
-import { AccountInfo, AptosSignMessageInput, UserResponseStatus } from '@aptos-labs/wallet-standard'
+import {
+  AccountAuthenticator,
+  AccountAuthenticatorEd25519,
+  AnyRawTransaction,
+  Aptos,
+  AccountPublicKey,
+  Network
+} from '@aptos-labs/ts-sdk'
+import {
+  AccountInfo,
+  AptosSignAndSubmitTransactionInput,
+  AptosSignMessageInput,
+  UserResponseStatus
+} from '@aptos-labs/wallet-standard'
 import { NightlyConnectAptosAdapter } from '@nightlylabs/wallet-selector-aptos'
 import { createEffect, createSignal, onMount, Show } from 'solid-js'
 import { Title } from '@solidjs/meta'
@@ -30,19 +42,19 @@ export default function AptosPage() {
           '--nc-img-logo': 'url(https://alephzero.org/aleph-design/brand-elements/logo-day.svg)'
         },
         stylesOverride: `
-          .nc_headerWrapper {
-            background-color: blue;
-          }
-  
-          .nc_headerLogo {
-            width: 200px;
-          }
-  
-          .nc_modalContent {
-            border-radius: 0;
-            border: 3px dashed var(--nc-color-primary);
-          }
-          `,
+      .nc_headerWrapper {
+        background-color: blue;
+      }
+
+      .nc_headerLogo {
+        width: 200px;
+      }
+
+      .nc_modalContent {
+        border-radius: 0;
+        border: 3px dashed var(--nc-color-primary);
+      }
+      `,
         qrConfigOverride: {
           dotsOptions: {
             color: 'purple'
@@ -59,7 +71,9 @@ export default function AptosPage() {
       })
 
       adapter.on('connect', (accInfo) => {
-        setAccountInfo(accInfo)
+        if (accInfo && 'address' in accInfo) {
+          setAccountInfo(accInfo)
+        }
       })
 
       adapter.on('disconnect', () => {
@@ -68,7 +82,9 @@ export default function AptosPage() {
       })
 
       adapter.on('accountChange', (accInfo) => {
-        setAccountInfo(accInfo)
+        if (accInfo && 'address' in accInfo) {
+          setAccountInfo(accInfo)
+        }
       })
 
       setAdapter(adapter)
@@ -89,12 +105,27 @@ export default function AptosPage() {
     }
   })
 
+  const handleCreateAccountDevnet = async (address: string) => {
+    try {
+      // if account exists it doesnt throw an error
+      await aptos.getAccountInfo({
+        accountAddress: address
+      })
+    } catch {
+      // if account doesnt exist fund it on devnet (since we are using Aptos on devnet)
+      await aptos.fundAccount({
+        accountAddress: address,
+        amount: 100_000_000
+      })
+    }
+  }
+
   return (
     <main>
       <Title>Aptos Example</Title>
       <div id="modalAnchor" />
       <Show
-        when={!!accountInfo()}
+        when={!!accountInfo()?.address}
         fallback={
           <button
             onClick={() => {
@@ -112,22 +143,41 @@ export default function AptosPage() {
             Connect
           </button>
         }>
-        <h1>Current address: {accountInfo()?.address.toString()}</h1>
+        <h1>Current address: {accountInfo()?.address?.toString()}</h1>
         <button
           onClick={async () => {
             try {
-              const transaction = await aptos.transaction.build.simple({
-                sender: accountInfo()!.address.toString(),
-                data: {
-                  function: '0x1::coin::transfer',
-                  typeArguments: ['0x1::aptos_coin::AptosCoin'],
-                  functionArguments: [
-                    '0x960dbc655b847cad38b6dd056913086e5e0475abc27152b81570fd302cb10c38',
-                    100
-                  ]
+              const address = accountInfo()!.address?.toString()
+              await handleCreateAccountDevnet(address)
+              let signedTx
+              if (
+                adapter()!.selectedWallet?.name === 'Nightly' &&
+                adapter()!.selectedWallet?.walletType !== 'mobile'
+              ) {
+                // is nightly extension (uses newer version of @aptos-labs/wallet-standard)
+                const nightlyTransaction = {
+                  payload: {
+                    function: '0x1::coin::transfer',
+                    typeArguments: ['0x1::aptos_coin::AptosCoin'],
+                    functionArguments: [address, 100]
+                  }
                 }
-              })
-              const signedTx = await adapter()!.signAndSubmitTransaction(transaction)
+                signedTx = await adapter()!.signAndSubmitTransaction(nightlyTransaction as any)
+              } else {
+                const transaction = await aptos.transaction.build.simple({
+                  sender: address,
+                  data: {
+                    function: '0x1::coin::transfer',
+                    typeArguments: ['0x1::aptos_coin::AptosCoin'],
+                    functionArguments: [
+                      '0x960dbc655b847cad38b6dd056913086e5e0475abc27152b81570fd302cb10c38',
+                      100
+                    ]
+                  }
+                })
+                signedTx = await adapter()!.signAndSubmitTransaction(transaction)
+              }
+
               // Verify the transaction was signed
               if (signedTx.status !== UserResponseStatus.APPROVED) {
                 toast.error('Transaction was not approved')
@@ -145,8 +195,10 @@ export default function AptosPage() {
         <button
           onClick={async () => {
             try {
+              const address = accountInfo()!.address?.toString()
+              await handleCreateAccountDevnet(address)
               const transaction = await aptos.transaction.build.simple({
-                sender: accountInfo()!.address.toString(),
+                sender: address,
                 data: {
                   function: '0x1::coin::transfer',
                   typeArguments: ['0x1::aptos_coin::AptosCoin'],

--- a/sdk/apps/modal-example/src/routes/aptosCustom.tsx
+++ b/sdk/apps/modal-example/src/routes/aptosCustom.tsx
@@ -4,7 +4,8 @@ import {
   AnyRawTransaction,
   Aptos,
   AccountPublicKey,
-  Network
+  Network,
+  AptosConfig
 } from '@aptos-labs/ts-sdk'
 import {
   AccountInfo,
@@ -17,7 +18,10 @@ import { createEffect, createSignal, onMount, Show } from 'solid-js'
 import { Title } from '@solidjs/meta'
 import toast from 'solid-toast'
 
-const aptos = new Aptos() // default to devnet
+const aptosConfig = new AptosConfig({
+  network: Network.MAINNET
+})
+const aptos = new Aptos(aptosConfig)
 
 export default function AptosPage() {
   const [adapter, setAdapter] = createSignal<NightlyConnectAptosAdapter>()
@@ -42,19 +46,19 @@ export default function AptosPage() {
           '--nc-img-logo': 'url(https://alephzero.org/aleph-design/brand-elements/logo-day.svg)'
         },
         stylesOverride: `
-      .nc_headerWrapper {
-        background-color: blue;
-      }
+  .nc_headerWrapper {
+    background-color: blue;
+  }
 
-      .nc_headerLogo {
-        width: 200px;
-      }
+  .nc_headerLogo {
+    width: 200px;
+  }
 
-      .nc_modalContent {
-        border-radius: 0;
-        border: 3px dashed var(--nc-color-primary);
-      }
-      `,
+  .nc_modalContent {
+    border-radius: 0;
+    border: 3px dashed var(--nc-color-primary);
+  }
+  `,
         qrConfigOverride: {
           dotsOptions: {
             color: 'purple'
@@ -105,21 +109,6 @@ export default function AptosPage() {
     }
   })
 
-  const handleCreateAccountDevnet = async (address: string) => {
-    try {
-      // if account exists it doesnt throw an error
-      await aptos.getAccountInfo({
-        accountAddress: address
-      })
-    } catch {
-      // if account doesnt exist fund it on devnet (since we are using Aptos on devnet)
-      await aptos.fundAccount({
-        accountAddress: address,
-        amount: 100_000_000
-      })
-    }
-  }
-
   return (
     <main>
       <Title>Aptos Example</Title>
@@ -147,36 +136,18 @@ export default function AptosPage() {
         <button
           onClick={async () => {
             try {
-              const address = accountInfo()!.address?.toString()
-              await handleCreateAccountDevnet(address)
-              let signedTx
-              if (
-                adapter()!.selectedWallet?.name === 'Nightly' &&
-                adapter()!.selectedWallet?.walletType !== 'mobile'
-              ) {
-                // is nightly extension (uses newer version of @aptos-labs/wallet-standard)
-                const nightlyTransaction = {
-                  payload: {
-                    function: '0x1::coin::transfer',
-                    typeArguments: ['0x1::aptos_coin::AptosCoin'],
-                    functionArguments: [address, 100]
-                  }
+              const transaction = await aptos.transaction.build.simple({
+                sender: accountInfo()!.address?.toString(),
+                data: {
+                  function: '0x1::coin::transfer',
+                  typeArguments: ['0x1::aptos_coin::AptosCoin'],
+                  functionArguments: [
+                    '0x960dbc655b847cad38b6dd056913086e5e0475abc27152b81570fd302cb10c38',
+                    100
+                  ]
                 }
-                signedTx = await adapter()!.signAndSubmitTransaction(nightlyTransaction as any)
-              } else {
-                const transaction = await aptos.transaction.build.simple({
-                  sender: address,
-                  data: {
-                    function: '0x1::coin::transfer',
-                    typeArguments: ['0x1::aptos_coin::AptosCoin'],
-                    functionArguments: [
-                      '0x960dbc655b847cad38b6dd056913086e5e0475abc27152b81570fd302cb10c38',
-                      100
-                    ]
-                  }
-                })
-                signedTx = await adapter()!.signAndSubmitTransaction(transaction)
-              }
+              })
+              const signedTx = await adapter()!.signAndSubmitTransaction(transaction)
 
               // Verify the transaction was signed
               if (signedTx.status !== UserResponseStatus.APPROVED) {
@@ -195,10 +166,8 @@ export default function AptosPage() {
         <button
           onClick={async () => {
             try {
-              const address = accountInfo()!.address?.toString()
-              await handleCreateAccountDevnet(address)
               const transaction = await aptos.transaction.build.simple({
-                sender: address,
+                sender: accountInfo()!.address?.toString(),
                 data: {
                   function: '0x1::coin::transfer',
                   typeArguments: ['0x1::aptos_coin::AptosCoin'],
@@ -249,8 +218,12 @@ export default function AptosPage() {
                 nonce: 'YOLO'
               }
               const signed = await adapter()!.signMessage(msgToSign)
-              if (signed.status !== UserResponseStatus.APPROVED) {
-                throw new Error('Message was not approved')
+
+              if ('signature' in signed) {
+                if (!signed.signature) throw new Error('Message was not approved')
+              } else {
+                if (signed.status !== UserResponseStatus.APPROVED)
+                  throw new Error('Message was not approved')
               }
               toast.success('Message was signed!')
             } catch (e) {

--- a/sdk/packages/aptos/src/app.ts
+++ b/sdk/packages/aptos/src/app.ts
@@ -15,6 +15,8 @@ import {
   TransactionToSign
 } from '@nightlylabs/nightly-connect-base'
 import { EventEmitter } from 'eventemitter3'
+import { UserDisconnectedEvent } from '../../../bindings/UserDisconnectedEvent'
+import { WalletMetadata } from '../../../bindings/WalletMetadata'
 import {
   AppAptosInitialize,
   APTOS_NETWORK,
@@ -25,8 +27,6 @@ import {
   serializeAptosTx,
   serializeObject
 } from './utils'
-import { UserDisconnectedEvent } from '../../../bindings/UserDisconnectedEvent'
-import { WalletMetadata } from '../../../bindings/WalletMetadata'
 
 interface AptosAppEvents {
   userConnected: (e: AccountInfo, networkInfo: NetworkInfo) => void

--- a/sdk/packages/selector-aptos/package.json
+++ b/sdk/packages/selector-aptos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightlylabs/wallet-selector-aptos",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "type": "module",
   "exports": {

--- a/sdk/pnpm-lock.yaml
+++ b/sdk/pnpm-lock.yaml
@@ -84,7 +84,7 @@ importers:
       '@nightlylabs/nightly-connect-polkadot': 0.0.16
       '@nightlylabs/nightly-connect-solana': 0.0.29
       '@nightlylabs/nightly-connect-sui': 0.1.0
-      '@nightlylabs/wallet-selector-aptos': 0.1.6
+      '@nightlylabs/wallet-selector-aptos': 0.1.7
       '@nightlylabs/wallet-selector-base': ^0.4.1
       '@nightlylabs/wallet-selector-polkadot': 0.2.7
       '@nightlylabs/wallet-selector-solana': 0.3.6


### PR DESCRIPTION
Due to the fact that nightly extension uses a dependency @aptos-labs/wallet-standard version 0.1.0 and for example Pontem Wallet Extension uses a version 0.0.11 the type of the transaction required in signAndSubmitTransaction is different. Therefore i believe it is more reasonable to split the interfaces for the time being, since it should be only a matter of time since pontem wallet updates its sdk.